### PR TITLE
Update CLI to use ES module syntax

### DIFF
--- a/.changeset/tidy-roses-tease.md
+++ b/.changeset/tidy-roses-tease.md
@@ -1,0 +1,5 @@
+---
+"@rccpr/cli": patch
+---
+
+Update the CLI to utilize ES module syntax

--- a/packages/cli/cli
+++ b/packages/cli/cli
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import './dist/index.mjs';
+import './dist/index.js';

--- a/packages/cli/cli
+++ b/packages/cli/cli
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require("./dist/index.js");
+import './dist/index.mjs';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
+  "type": "module",
   "license": "MIT",
   "files": [
     "dist/**"

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig((options) => ({
   format: ["esm", "cjs"],
   sourcemap: true,
   minify: true,
-  target: "node14",
 }));


### PR DESCRIPTION
Update the CLI to utilize ES module syntax for improved compatibility and modern JavaScript practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the CLI module to support ES module syntax, enhancing compatibility and modernizing the codebase.

- **Chores**
	- Added `"type": "module"` to the package configuration, indicating the package is designed for ECMAScript modules.
	- Removed the target restriction in the build configuration, allowing for broader compatibility with different Node.js versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->